### PR TITLE
Optional purpose maskable icons

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,14 +9,17 @@
     "icons": [{
         "src": "libs/image/AP-dev1.png",
         "size": "567x567",
-        "type": "image/png"
+        "type": "image/png",
+        "purpose": "any"
     },{
         "src":"libs/image/ap-dev1_144x144.png",
         "size":"144x144",
-        "type":"image/png"
+        "type":"image/png",
+        "purpose": "any"
     },{
         "src":"libs/image/AP-dev1.png",
         "size":"514x514",
-        "type":"image/png"
+        "type":"image/png",
+        "purpose": "any"
     }]
   }


### PR DESCRIPTION
With the inclusion of maskable icons, a new property value has been added for image resources listed in a Web App Manifest. The purpose field tells the browser how your icon should be used. By default, icons will have a purpose of "any". These icons will be resized on top of a white background on Android.

Maskable icons should use a different purpose: "maskable". This indicates that an image is meant to be used with icon masks, giving you more control over the result. This way, your icons will not have a white background. You can also specify multiple space-separated purposes (for example, "any maskable"), if you want your maskable icon to be used without a mask on other devices.