### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "express": "^4.21.2",
     "http-errors": "~1.6.3",
     "jquery": "^3.6.0",
-    "morgan": "~1.10.1"
+    "morgan": "~1.10.1",
+    "express-rate-limit": "^8.0.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.9"

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,12 +1,19 @@
 var express = require('express');
 var router = express.Router();
 
+// Add rate limiter for the '/cv' route
+var rateLimit = require('express-rate-limit');
+const cvLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 5, // limit each IP to 5 requests per windowMs
+  message: "Too many download requests from this IP, please try again after a minute."
+});
 
 router.get('/', function(req, res, next) {
   res.render('index', { title: 'Alfonso Pisicchio' });
 });
 
-router.get('/cv', (req, res, next)=>{
+router.get('/cv', cvLimiter, (req, res, next)=>{
   res.download('./CV.pdf');
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/Forz70043/Forz70043.github.io/security/code-scanning/1](https://github.com/Forz70043/Forz70043.github.io/security/code-scanning/1)

The best way to fix this problem is to add rate-limiting middleware to the `/cv` route, ensuring that repeated or automated requests to download the file cannot overload the server. This can be achieved by using a well-known library such as `express-rate-limit`. Given that only the `/cv` route is at immediate risk due to the direct file download, we can limit the scope of the rate-limiter to just this route to avoid potentially affecting other routes unnecessarily. Specifically, we will import (i.e., require) `express-rate-limit`, define a rate limiter instance with sensible limits (e.g., 5 downloads per IP per minute), and add it as middleware to the `/cv` route. All necessary modifications will be within the `routes/index.js` file: one import, one limiter definition, and a code change in the relevant route definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
